### PR TITLE
Fix and re-writes

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,6 +6,6 @@ DEPENDENCIES
     path: test/fixtures/cookbooks/deploy_artifact_test
 
 GRAPH
-  deploy_artifact (1.0.0)
+  deploy_artifact (1.1.1)
   deploy_artifact_test (0.0.1)
     deploy_artifact (>= 0.0.0)

--- a/test/integration/tarball/serverspec/keep_releases_spec.rb
+++ b/test/integration/tarball/serverspec/keep_releases_spec.rb
@@ -2,11 +2,16 @@ require 'spec_helper'
 require 'digest/md5'
 
 describe file('/var/keep_releases/current') do
-  it { should be_directory }
+  it { should be_symlink }
 end
 
 describe file('/var/keep_releases/cached-copy/keep_releases.tar.gz') do
   it { should be_file }
+end
+
+cached_checksum = Digest::MD5.hexdigest(File.read('/var/keep_releases/cached-copy/keep_releases.tar.gz'))
+describe file("/var/keep_releases/releases/#{cached_checksum}") do
+  it { should be_directory }
 end
 
 describe command('tar --compare -f /var/keep_releases/cached-copy/keep_releases.tar.gz \


### PR DESCRIPTION
- Fix for compare method
- Removed check_if_released method in favor of just remove_stale
- Fix for removing stale current/releases
- Fix to do_deploy only when releases directory is empty
- Removed direct deploy to current directory when keep_releases false
  due to being infeasible
- Added handling of @LongLink tar entries
- Re-write untar method to be less complex adding helper methods
  file_open, tar_open, gzip_stream, dir_untar, file_untar, symlink_untar
- Updated testing
