### PR TITLE
Longlink fixes

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,6 +6,6 @@ DEPENDENCIES
     path: test/fixtures/cookbooks/deploy_artifact_test
 
 GRAPH
-  deploy_artifact (1.1.1)
+  deploy_artifact (1.2.1)
   deploy_artifact_test (0.0.1)
     deploy_artifact (>= 0.0.0)

--- a/libraries/provider_deploy_artifact.rb
+++ b/libraries/provider_deploy_artifact.rb
@@ -33,7 +33,7 @@ class Chef
         do_mkdir(release_directory)
 
         do_deploy_cached
-        symlink_current
+        do_deploy_release
 
         check_old_releases
       end
@@ -125,9 +125,9 @@ class Chef
         Chef::Log.info("#{new_resource} old_releases #{old_releases}")
       end
 
-      def symlink_current
+      def do_deploy_release
         return if ::File.exist?(current_file)
-        do_restart_command
+        do_before_symlink
         Chef::Log.info("#{new_resource} - creating symlink for current release #{release_file_checksum}")
         converge_by("linking new release #{release_file_checksum} as current") do
           ::File.symlink(release_file, current_file)

--- a/test/fixtures/cookbooks/deploy_artifact_test/attributes/default.rb
+++ b/test/fixtures/cookbooks/deploy_artifact_test/attributes/default.rb
@@ -1,0 +1,1 @@
+node.default['deploy_artifact_test']['targz'] = 'https://7b0018e452715ff0848f-5481afe383567f772af25cedbc74e5e4.ssl.cf5.rackcdn.com/latest-longlink.tar.gz'

--- a/test/fixtures/cookbooks/deploy_artifact_test/recipes/cache_path.rb
+++ b/test/fixtures/cookbooks/deploy_artifact_test/recipes/cache_path.rb
@@ -9,7 +9,7 @@ deploy_artifact file do
   action :deploy
   deploy_file do
     remote_file "#{cache_path}/#{file}" do
-      source 'https://wordpress.org/latest.tar.gz'
+      source node['deploy_artifact_test']['targz']
       owner 'root'
       group 'root'
       mode '0755'

--- a/test/fixtures/cookbooks/deploy_artifact_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/deploy_artifact_test/recipes/default.rb
@@ -8,7 +8,7 @@ end
 
 # Download sample wordpress install
 remote_file '/var/www/cached-copy/latest.tar.gz' do
-  source 'https://wordpress.org/latest.tar.gz'
+  source node['deploy_artifact_test']['targz']
   owner 'root'
   group 'root'
   mode '0755'

--- a/test/fixtures/cookbooks/deploy_artifact_test/recipes/deploy_file.rb
+++ b/test/fixtures/cookbooks/deploy_artifact_test/recipes/deploy_file.rb
@@ -7,7 +7,7 @@ deploy_artifact file do
   action :deploy
   deploy_file do
     remote_file "#{path}/cached-copy/#{file}" do
-      source 'https://wordpress.org/latest.tar.gz'
+      source node['deploy_artifact_test']['targz']
       owner 'root'
       group 'root'
       mode '0755'

--- a/test/fixtures/cookbooks/deploy_artifact_test/recipes/keep_releases.rb
+++ b/test/fixtures/cookbooks/deploy_artifact_test/recipes/keep_releases.rb
@@ -8,7 +8,7 @@ deploy_artifact file do
   action :deploy
   deploy_file do
     remote_file ::File.join(path, 'cached-copy', file) do
-      source 'https://wordpress.org/latest.tar.gz'
+      source node['deploy_artifact_test']['targz']
       owner 'root'
       group 'root'
       mode '0755'


### PR DESCRIPTION
- Fixes to fully support LongLink tar files
- Changed symlink_current method name to do_deploy_release
- Updating testing
