### PR TITLE
Adding fix if cached_file did not exist for remove_stale

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,6 +12,7 @@ provisioner:
 
 platforms:
   - name: centos-6.7
+  - name: centos-7
   - name: ubuntu-12.04
   - name: ubuntu-14.04
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.getchef.com'
 
+cookbook 'deploy_artifact_test', path: 'test/fixtures/cookbooks/deploy_artifact_test'
+
 metadata

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Overview
 
+#### Supports and Tested Against
+- CentOS 6.7
+- CentOS 7.1
+- Ubuntu 12.04 LTS
+- Ubuntu 14.04 LTS
+
 This cookbook provides a simple `deploy_artifact` resource that will deploy a single binary or tar.gz file. The deployment process is designed to mirror the [Deploy Resource](https://docs.chef.io/resource_deploy.html) except designed to be used only for local deployments and not GIT. It is assumed that a directory called `cached-copy` will already contain the contents of what is to be deployed if not configured. It is left up to you on how to deliver the artifact using the while the resource will do the work to deploy it. The resource determines whether a file should be deployed or not based off of the current `cached-copy` checksum and the current release directory checksum name. Mac PAX format tar files are not supported at this time.
 
 Given a `file` location and `path`, the resource will by default:

--- a/libraries/provider_deploy_artifact.rb
+++ b/libraries/provider_deploy_artifact.rb
@@ -137,7 +137,7 @@ class Chef
       end
 
       def remove_stale
-        if ::File.exist?(current_file)
+        if ::File.exist?(current_file) && ::File.exist?(cached_file)
           unless compare?(cached_file, current_file)
             Chef::Log.info("#{new_resource} - removing non-matching release to re-deploy")
             converge_by('removing non-matching release to re-deploy') do


### PR DESCRIPTION
- Fixed issue with remove_stale method failing if cached_file was not present
- Added centos 7 support
